### PR TITLE
Fix deprecated functionality: explode(): Passing null to parameter #2…

### DIFF
--- a/Job/SetNotVisible.php
+++ b/Job/SetNotVisible.php
@@ -58,7 +58,7 @@ class SetNotVisible
     {
         return explode(
             ',',
-            $this->config->getValue(static::CONFIG_PREFIX . static::NOT_VISIBLE_CONFIG_KEY)
+            $this->config->getValue(static::CONFIG_PREFIX . static::NOT_VISIBLE_CONFIG_KEY) ?? ''
         );
     }
 }


### PR DESCRIPTION
… () of type string is deprecated