### PR TITLE
Fix tax class mapping with localizable and scopeable attribute.

### DIFF
--- a/Plugin/Helper/Import/Entities.php
+++ b/Plugin/Helper/Import/Entities.php
@@ -50,7 +50,7 @@ class Entities
                     $data['tax_class_id'] = new \Zend_Db_Expr(
                         "IF(`".$data[$key]."` IS NULL OR `".$data[$key]."` = '', '".$defaultTaxClassId."', `".$data[$key]."`)"
                     );
-                } else {
+                } elseif (isset($data[$key])) {
                     $data['tax_class_id'] = new \Zend_Db_Expr(
                         "IF(`".$data[$key]."` IS NULL OR `".$data[$key]."` = '', `_tax_class_id`, `".$data[$key]."`)"
                     );

--- a/Plugin/Helper/Import/Entities.php
+++ b/Plugin/Helper/Import/Entities.php
@@ -44,13 +44,13 @@ class Entities
         $additonalTypes = $this->attributeHelper->getAdditionalTypes();
 
         foreach ($additonalTypes as $key => $additonalType) {
-            if ($additonalType ===  'tax') {
+            if ($additonalType ===  'tax' && isset($data[$key])) {
                 if (isset($data['tax_class_id']) && $data['tax_class_id'] instanceof \Zend_Db_Expr) {
                     $defaultTaxClassId = $data['tax_class_id']->__toString();
                     $data['tax_class_id'] = new \Zend_Db_Expr(
                         "IF(`".$data[$key]."` IS NULL OR `".$data[$key]."` = '', '".$defaultTaxClassId."', `".$data[$key]."`)"
                     );
-                } elseif (isset($data[$key])) {
+                } else {
                     $data['tax_class_id'] = new \Zend_Db_Expr(
                         "IF(`".$data[$key]."` IS NULL OR `".$data[$key]."` = '', `_tax_class_id`, `".$data[$key]."`)"
                     );

--- a/Plugin/Helper/Import/Entities.php
+++ b/Plugin/Helper/Import/Entities.php
@@ -5,18 +5,16 @@ namespace JustBetter\AkeneoBundle\Plugin\Helper\Import;
 use Magento\Store\Model\ScopeInterface as scope;
 use Akeneo\Connector\Helper\Store as StoreHelper;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Akeneo\Connector\Helper\Import\Attribute as AttributeHelper;
 
 class Entities
 {
-    protected $config;
-    protected $storeHelper;
 
     public function __construct(
-        ScopeConfigInterface $config,
-        StoreHelper $storeHelper
+        protected ScopeConfigInterface $config,
+        protected StoreHelper $storeHelper,
+        protected AttributeHelper $attributeHelper
     ) {
-        $this->config = $config;
-        $this->storeHelper = $storeHelper;
     }
 
     public function afterFormatMediaName($subject, $result)
@@ -27,5 +25,38 @@ class Entities
         }
 
         return str_replace("_", "-", $result);
+    }
+
+    /**
+     * Before setting the values we use Tax Type value from Akeneo when available
+     *
+     * @param $subject
+     * @param $jobCode
+     * @param $entityTable
+     * @param $data
+     * @param $entityTypeId
+     * @param $storeId
+     * @param $mode
+     * @return array
+     */
+    public function beforesetValues($subject, $jobCode, $entityTable, $data, $entityTypeId, $storeId, $mode)
+    {
+        $additonalTypes = $this->attributeHelper->getAdditionalTypes();
+
+        foreach ($additonalTypes as $key => $additonalType) {
+            if ($additonalType ===  'tax') {
+                if (isset($data['tax_class_id']) && $data['tax_class_id'] instanceof \Zend_Db_Expr) {
+                    $defaultTaxClassId = $data['tax_class_id']->__toString();
+                    $data['tax_class_id'] = new \Zend_Db_Expr(
+                        "IF(`".$data[$key]."` IS NULL OR `".$data[$key]."` = '', '".$defaultTaxClassId."', `".$data[$key]."`)"
+                    );
+                } else {
+                    $data['tax_class_id'] = new \Zend_Db_Expr(
+                        "IF(`".$data[$key]."` IS NULL OR `".$data[$key]."` = '', `_tax_class_id`, `".$data[$key]."`)"
+                    );
+                }
+            }
+        }
+        return [$jobCode, $entityTable, $data, $entityTypeId, $storeId, $mode];
     }
 }

--- a/Plugin/SetTaxClassId.php
+++ b/Plugin/SetTaxClassId.php
@@ -3,7 +3,6 @@
 namespace JustBetter\AkeneoBundle\Plugin;
 
 use Akeneo\Connector\Job\Product;
-use Akeneo\Connector\Helper\Config;
 use Akeneo\Connector\Helper\Authenticator;
 use Akeneo\Connector\Helper\Store as StoreHelper;
 use Akeneo\Connector\Helper\Config as ConfigHelper;
@@ -98,6 +97,10 @@ class SetTaxClassId
      */
     public function beforeUpdateOption($subject)
     {
+        if (!$this->tax_id_columns) {
+            return [$subject];
+        }
+
         $connection = $this->entitiesHelper->getConnection();
         $tmpTable = $this->entitiesHelper->getTableName($subject->getCode());
 

--- a/Plugin/SetTaxClassId.php
+++ b/Plugin/SetTaxClassId.php
@@ -88,48 +88,31 @@ class SetTaxClassId
         if (empty($taxColumns)) {
             return;
         }
-
-        foreach ($taxColumns as $tax_id_column) {
-            $taxQuery = $this->createQuery($tax_id_column, $tmpTable);
-            if (!$taxQuery) {
-                return;
-            }
-            try {
-                $connection = $this->entitiesHelper->getConnection();
-                $connection->query($taxQuery);
-            } catch (Exception $e) {
-                throw $e;
-            }
-        }
     }
 
     /**
-     * In Case the Akeneo attribute is called tax_class_id
+     * Before UpdateOption - Map Akeneo Tax Class option to Magento counterpart
      *
-     * @param Product $context
+     * @param $subject
+     * @return array
      */
-    public function afterUpdateOption(Product $context): void
+    public function beforeUpdateOption($subject)
     {
-        $extensionEnabled = $this->scopeConfig->getValue('akeneo_connector/justbetter/settaxclass', scope::SCOPE_WEBSITE);
-        if (!$extensionEnabled) {
-            return;
-        }
-
-        /** @var AdapterInterface $connection */
         $connection = $this->entitiesHelper->getConnection();
-        $tmpTable = $this->entitiesHelper->getTableName($context->getCode());
-        $tax_id_column_original = '_tax_class_id';
+        $tmpTable = $this->entitiesHelper->getTableName($subject->getCode());
 
         if ($taxColumns = $this->checkTaxColumnsExist($this->tax_id_columns, $tmpTable)) {
             foreach ($taxColumns as $tax_id_column) {
                 try {
-                    $connection->query("UPDATE `".$tmpTable."` SET `".$tax_id_column."` = `".$tax_id_column_original."`");
+                    $taxQuery = $this->createQuery($tax_id_column, $tmpTable);
+                    $connection->query($taxQuery);
                 } catch (Exception $e) {
                     throw $e;
                 }
             }
         }
-        return;
+
+        return [$subject];
     }
 
     /**
@@ -144,7 +127,7 @@ class SetTaxClassId
     {
         $query = "
             UPDATE `" . $tableName . "`
-            SET `_tax_class_id` =
+            SET `".$tax_id_column."` =
             ";
 
         $query = $this->addCase($query, $tax_id_column);
@@ -179,8 +162,7 @@ class SetTaxClassId
             ";
         }
 
-        $query .= 'ELSE `_tax_class_id`
-        END';
+        $query .= 'END';
 
         return $query;
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "justbetter/magento2-akeneo-bundle",
     "description": "Magento2 bundle for extending the Akeneo connector with awesome features.",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "akeneo/module-magento2-connector-community": "*"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Refactor of the tax class mapping when the attribute is both localizable and scopeable.
This is tested with both localizable, scopeable and global tax class attributes. 

We check for a storeview specific value, and use the default tax class as a fallback. If both are not present we use the value from column `_tax_class_id` (default akeneo connector module and should be default to `0`).