### PR TITLE
Reset tax_id_columns

### DIFF
--- a/Plugin/SetTaxClassId.php
+++ b/Plugin/SetTaxClassId.php
@@ -70,6 +70,7 @@ class SetTaxClassId
 
         $mappings = $this->serializer->unserialize($mappings);
 
+        $this->tax_id_columns = [];
         foreach ($attributes as $attribute) {
             if ($attribute['magento_type'] === "tax") {
                 $this->tax_id_columns[] = $attribute['pim_type'];


### PR DESCRIPTION
The `tax_id_columns` were not reset before every new family import. I tried moving the declaration of the variable to a different function on the class, to prevent the code from running multiple times. This seems not possible and fetching magento configuration in the `__construct` is not really wanted.

Not resetting `the tax_id_columns` result in missing custom `tax_class` mappings.