### PR TITLE
PHP 8.4 deprecation warnings

### DIFF
--- a/Console/Command/ImportMetricUnits.php
+++ b/Console/Command/ImportMetricUnits.php
@@ -11,7 +11,7 @@ class ImportMetricUnits extends Command
 {
     protected ImportMetricUnitsJob $job;
 
-    public function __construct(ImportMetricUnitsJob $job, string $name = null)
+    public function __construct(ImportMetricUnitsJob $job, ?string $name = null)
     {
         $this->job = $job;
 

--- a/Console/Command/SetNotVisible.php
+++ b/Console/Command/SetNotVisible.php
@@ -11,7 +11,7 @@ class SetNotVisible extends Command
 {
     protected SetNotVisibleJob $job;
 
-    public function __construct(SetNotVisibleJob $job, string $name = null)
+    public function __construct(SetNotVisibleJob $job, ?string $name = null)
     {
         $this->job = $job;
 

--- a/Console/Command/SlackNotificationCommand.php
+++ b/Console/Command/SlackNotificationCommand.php
@@ -15,7 +15,7 @@ class SlackNotificationCommand extends Command
 {
     protected $runSlackMessage;
 
-    public function __construct(RunSlackMessage $runSlackMessage, $name = null)
+    public function __construct(RunSlackMessage $runSlackMessage, ?string $name = null)
     {
         $this->runSlackMessage = $runSlackMessage;
         parent::__construct($name);

--- a/Helper/SlackHelper.php
+++ b/Helper/SlackHelper.php
@@ -14,7 +14,7 @@ class SlackHelper extends AbstractHelper
      * @param  String $field
      * @param  Int $storeId
      */
-    public function getConfigValue($field, $storeId = null)
+    public function getConfigValue($field, ?int $storeId = null)
     {
         return $this->scopeConfig->getValue(
             $field,
@@ -28,7 +28,7 @@ class SlackHelper extends AbstractHelper
      * @param  String $code
      * @param  null $storeId
      */
-    public function getGeneralConfig($code, $storeId = null)
+    public function getGeneralConfig($code, ?int $storeId = null)
     {
         return $this->getConfigValue(self::XML_PATH . $code, $storeId);
     }

--- a/Job/ImportMetricUnits.php
+++ b/Job/ImportMetricUnits.php
@@ -32,7 +32,7 @@ class ImportMetricUnits
         $this->config = $config;
     }
 
-    public function execute(OutputInterface $output = null): void
+    public function execute(?OutputInterface $output = null): void
     {
         if (! $this->authenticator->getAkeneoApiClient()) {
             if ($output) {

--- a/Job/RunSlackMessage.php
+++ b/Job/RunSlackMessage.php
@@ -18,7 +18,7 @@ class RunSlackMessage
     protected $logs;
     protected $slackMessage;
 
-    public function execute(InputInterface $input = null, OutputInterface $output = null)
+    public function execute(?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $message = $this->getMessage();
         if ($this->helperData->isEnable()) {

--- a/Job/SetNotVisible.php
+++ b/Job/SetNotVisible.php
@@ -29,7 +29,7 @@ class SetNotVisible
         $this->action = $action;
     }
 
-    public function execute(OutputInterface $output = null): void
+    public function execute(?OutputInterface $output = null): void
     {
         $products = $this->collectionFactory->create()
             ->addFieldToFilter('attribute_set_id', ['in' => $this->getNotVisibleFamilies()])

--- a/Job/SlackMessage.php
+++ b/Job/SlackMessage.php
@@ -29,7 +29,7 @@ class SlackMessage
      * @param Collection $processingLogs
      * @return string
      */
-    public function warning(Collection $errorLogs = null, Collection $processingLogs = null)
+    public function warning(?Collection $errorLogs = null, ?Collection $processingLogs = null)
     {
         $message = ':warning: *Warning!* There\'s a problem with today’s imports in *' . $this->store->getName()
             . "*.\n\n";

--- a/Plugin/Helper/Import/Product.php
+++ b/Plugin/Helper/Import/Product.php
@@ -15,7 +15,7 @@ class Product
     ) {
     }
 
-    public function beforeCreateTmpTableFromApi($subject, $result, $tableSuffix, $family = null)
+    public function beforeCreateTmpTableFromApi($subject, $result, $tableSuffix, mixed $family = null)
     {
         if (is_null($this->codes)) {
             $this->codes = explode(',', (string)$this->config->getValue('akeneo_connector/justbetter/important_attributes'));


### PR DESCRIPTION
Convert all implicit nullable parameters to explicit nullable type hints (?type) to resolve PHP 8.4 deprecation warnings across AkeneoBundle