### PR TITLE
Add dynamic family filter option based on updated products to optimize large catalog import

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,6 +11,7 @@ This document provides detailed information about all features available in the 
   - [Important Attributes](#important-attributes)
   - [Default Store Values for Required Attributes](#default-store-values)
   - [Exclude Families from Import](#exclude-families)
+  - [Dynamic Family Filtering](#dynamic-family-filtering)
   - [Remove Redundant EAV Attributes](#remove-redundant-eav)
 - [Category Features](#category-features)
   - [Category Exist - Skip URL Path Regeneration](#category-exist)
@@ -88,6 +89,24 @@ Prevents specific product families from being imported. Products belonging to ex
 **Configuration:** `Stores > Configuration > Catalog > Akeneo Connector > Products Filters > Excluded Families`
 
 **Note:** This feature works in combination with the "Family Attribute as Filter" configuration.
+
+---
+
+### Dynamic Family Filtering
+<a id="dynamic-family-filtering"></a>
+
+Speeds up product imports for large catalogs by only processing families that have updated products within the configured "Updated Mode" period.
+
+**How it works:**
+1. Before import starts, queries Akeneo API for products updated within the configured period
+2. Extracts unique family codes from those products
+3. Only imports families that have updates, skipping all others
+
+**Configuration:** `Stores > Configuration > Catalog > Akeneo Connector > Products Filters > Dynamic Family Filtering`
+
+**Example:** Catalog has 936 families. With "Updated Mode" set to "Since Last 2 Days" and only 5 products updated, only 5 families are processed instead of all 936.
+
+**Important:** This feature uses the existing "Updated Mode" configuration from the Akeneo Connector. Make sure your update filter is properly configured.
 
 ---
 

--- a/Plugin/Job/Product.php
+++ b/Plugin/Job/Product.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace JustBetter\AkeneoBundle\Plugin\Job;
 
 use Akeneo\Connector\Job\Product as AkeneoProduct;
 use Akeneo\Connector\Model\Source\Filters\Family;
+use JustBetter\AkeneoBundle\Service\DynamicFamilyFilter;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Product
@@ -13,7 +15,8 @@ class Product
 
     public function __construct(
         protected ScopeConfigInterface $scopeConfig,
-        protected Family $familyFilter
+        protected Family $familyFilter,
+        protected DynamicFamilyFilter $dynamicFamilyFilter
     ) {
     }
 
@@ -35,6 +38,13 @@ class Product
             $families = is_array($allFamilies) ? array_values($allFamilies) : [];
         }
 
-        return array_diff($families, $familiesToExclude);
+        $families = array_diff($families, $familiesToExclude);
+
+        $dynamicFamilies = $this->dynamicFamilyFilter->getFamiliesWithUpdatedProducts();
+        if ($dynamicFamilies !== null) {
+            $families = array_intersect($families, $dynamicFamilies);
+        }
+
+        return array_values($families);
     }
 }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ For configuration instructions and best practices, see **[Configuration Guide](F
 | **<a href="FEATURES.md#product-import-features">Product Import</a>** | <a href="FEATURES.md#important-attributes">Important Attributes</a> | JustBetter Akeneo > Important Attributes |
 | | <a href="FEATURES.md#default-store-values">Default Store Values</a> | JustBetter Akeneo > Default Store Values |
 | | <a href="FEATURES.md#exclude-families">Exclude Families from Import</a> | Products Filters > Excluded Families |
+| | <a href="FEATURES.md#dynamic-family-filtering">Dynamic Family Filtering</a> | Products Filters > Dynamic Family Filtering |
 | | <a href="FEATURES.md#remove-redundant-eav">Remove Redundant EAV</a> | JustBetter Akeneo > Remove Redundant EAV |
 | **<a href="FEATURES.md#category-features">Category</a>** | <a href="FEATURES.md#category-exist">Category Exist - Skip URL Regeneration</a> | JustBetter Akeneo > Category Exist |
 | **<a href="FEATURES.md#tax--pricing-features">Tax & Pricing</a>** | <a href="FEATURES.md#set-tax-class">Set Tax Class</a> | JustBetter Akeneo > Set Tax Class |

--- a/Service/DynamicFamilyFilter.php
+++ b/Service/DynamicFamilyFilter.php
@@ -7,6 +7,8 @@ namespace JustBetter\AkeneoBundle\Service;
 use Akeneo\Connector\Helper\Authenticator;
 use Akeneo\Connector\Helper\Config as ConfigHelper;
 use Akeneo\Connector\Model\Source\Filters\Update;
+use Akeneo\Pim\ApiClient\Search\SearchBuilder;
+use Akeneo\Pim\ApiClient\Search\SearchBuilderFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
@@ -20,7 +22,8 @@ class DynamicFamilyFilter
         protected Authenticator $authenticator,
         protected ConfigHelper $configHelper,
         protected ResourceConnection $resourceConnection,
-        protected TimezoneInterface $timezone
+        protected TimezoneInterface $timezone,
+        protected SearchBuilderFactory $searchBuilderFactory
     ) {
     }
 
@@ -43,22 +46,22 @@ class DynamicFamilyFilter
             return null;
         }
 
-        $filter = $this->buildUpdateFilter();
-        if (empty($filter)) {
+        $searchBuilder = $this->buildUpdateFilter();
+        if ($searchBuilder === null) {
             return null;
         }
 
         $families = [];
-        $searchFilters = ['updated' => [$filter]];
+        $filters = ['search' => $searchBuilder->getFilters()];
         $pageSize = $this->configHelper->getPaginationSize();
 
-        foreach ($client->getProductApi()->all($pageSize, ['search' => $searchFilters]) as $product) {
+        foreach ($client->getProductApi()->all($pageSize, $filters) as $product) {
             if (!empty($product['family'])) {
                 $families[] = $product['family'];
             }
         }
 
-        foreach ($client->getProductModelApi()->all($pageSize, ['search' => $searchFilters]) as $model) {
+        foreach ($client->getProductModelApi()->all($pageSize, $filters) as $model) {
             if (!empty($model['family'])) {
                 $families[] = $model['family'];
             }
@@ -67,81 +70,63 @@ class DynamicFamilyFilter
         return array_values(array_unique($families));
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function buildUpdateFilter(): array
+    protected function buildUpdateFilter(): ?SearchBuilder
     {
+        $searchBuilder = $this->searchBuilderFactory->create();
+
         return match ($this->configHelper->getUpdatedMode()) {
-            Update::GREATER_THAN => $this->greaterThan($this->configHelper->getUpdatedGreaterFilter()),
-            Update::LOWER_THAN => $this->lowerThan($this->configHelper->getUpdatedLowerFilter()),
+            Update::GREATER_THAN => $this->greaterThan($searchBuilder, $this->configHelper->getUpdatedGreaterFilter()),
+            Update::LOWER_THAN => $this->lowerThan($searchBuilder, $this->configHelper->getUpdatedLowerFilter()),
             Update::BETWEEN => $this->between(
+                $searchBuilder,
                 $this->configHelper->getUpdatedBetweenAfterFilter(),
                 $this->configHelper->getUpdatedBetweenBeforeFilter()
             ),
-            Update::SINCE_LAST_N_DAYS => $this->sinceLastNDays($this->configHelper->getUpdatedSinceFilter()),
-            Update::SINCE_LAST_N_HOURS => $this->sinceLastNHours($this->configHelper->getUpdatedSinceLastHoursFilter()),
-            Update::SINCE_LAST_IMPORT => $this->sinceLastImport(),
-            default => [],
+            Update::SINCE_LAST_N_DAYS => $this->sinceLastNDays($searchBuilder, $this->configHelper->getUpdatedSinceFilter()),
+            Update::SINCE_LAST_N_HOURS => $this->sinceLastNHours($searchBuilder, $this->configHelper->getUpdatedSinceLastHoursFilter()),
+            Update::SINCE_LAST_IMPORT => $this->sinceLastImport($searchBuilder),
+            default => null,
         };
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function greaterThan(?string $date): array
+    protected function greaterThan(SearchBuilder $searchBuilder, ?string $date): ?SearchBuilder
     {
-        return $date ? ['operator' => '>', 'value' => "$date 00:00:00"] : [];
+        return $date ? $searchBuilder->addFilter('updated', '>', "$date 00:00:00") : null;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function lowerThan(?string $date): array
+    protected function lowerThan(SearchBuilder $searchBuilder, ?string $date): ?SearchBuilder
     {
-        return $date ? ['operator' => '<', 'value' => "$date 23:59:59"] : [];
+        return $date ? $searchBuilder->addFilter('updated', '<', "$date 23:59:59") : null;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function between(?string $after, ?string $before): array
+    protected function between(SearchBuilder $searchBuilder, ?string $after, ?string $before): ?SearchBuilder
     {
         return ($after && $before)
-            ? ['operator' => 'BETWEEN', 'value' => ["$after 00:00:00", "$before 23:59:59"]]
-            : [];
+            ? $searchBuilder->addFilter('updated', 'BETWEEN', ["$after 00:00:00", "$before 23:59:59"])
+            : null;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function sinceLastNDays(?string $days): array
+    protected function sinceLastNDays(SearchBuilder $searchBuilder, ?string $days): ?SearchBuilder
     {
         if (!$days || !is_numeric($days)) {
-            return [];
+            return null;
         }
         $date = $this->timezone->date()->modify("-$days days");
 
-        return ['operator' => '>', 'value' => $date->format('Y-m-d H:i:s')];
+        return $searchBuilder->addFilter('updated', '>', $date->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function sinceLastNHours(?string $hours): array
+    protected function sinceLastNHours(SearchBuilder $searchBuilder, ?string $hours): ?SearchBuilder
     {
         if (!$hours || !is_numeric($hours)) {
-            return [];
+            return null;
         }
         $date = $this->timezone->date()->modify("-$hours hours");
 
-        return ['operator' => '>', 'value' => $date->format('Y-m-d H:i:s')];
+        return $searchBuilder->addFilter('updated', '>', $date->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function sinceLastImport(): array
+    protected function sinceLastImport(SearchBuilder $searchBuilder): ?SearchBuilder
     {
         $connection = $this->resourceConnection->getConnection();
         $date = $connection->fetchOne(
@@ -150,6 +135,6 @@ class DynamicFamilyFilter
                 ->where('code = ?', 'product')
         );
 
-        return $date ? ['operator' => '>', 'value' => $date] : [];
+        return $date ? $searchBuilder->addFilter('updated', '>', $date) : null;
     }
 }

--- a/Service/DynamicFamilyFilter.php
+++ b/Service/DynamicFamilyFilter.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\AkeneoBundle\Service;
+
+use Akeneo\Connector\Helper\Authenticator;
+use Akeneo\Connector\Helper\Config as ConfigHelper;
+use Akeneo\Connector\Model\Source\Filters\Update;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+
+class DynamicFamilyFilter
+{
+    public const CONFIG_PATH_ENABLED = 'akeneo_connector/products_filters/dynamic_families_enabled';
+
+    public function __construct(
+        protected ScopeConfigInterface $scopeConfig,
+        protected Authenticator $authenticator,
+        protected ConfigHelper $configHelper,
+        protected ResourceConnection $resourceConnection,
+        protected TimezoneInterface $timezone
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLED);
+    }
+
+    /**
+     * @return array<string>|null
+     */
+    public function getFamiliesWithUpdatedProducts(): ?array
+    {
+        if (!$this->isEnabled()) {
+            return null;
+        }
+
+        $client = $this->authenticator->getAkeneoApiClient();
+        if ($client === null) {
+            return null;
+        }
+
+        $filter = $this->buildUpdateFilter();
+        if (empty($filter)) {
+            return null;
+        }
+
+        $families = [];
+        $searchFilters = ['updated' => [$filter]];
+        $pageSize = $this->configHelper->getPaginationSize();
+
+        foreach ($client->getProductApi()->all($pageSize, ['search' => $searchFilters]) as $product) {
+            if (!empty($product['family'])) {
+                $families[] = $product['family'];
+            }
+        }
+
+        foreach ($client->getProductModelApi()->all($pageSize, ['search' => $searchFilters]) as $model) {
+            if (!empty($model['family'])) {
+                $families[] = $model['family'];
+            }
+        }
+
+        return array_values(array_unique($families));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildUpdateFilter(): array
+    {
+        return match ($this->configHelper->getUpdatedMode()) {
+            Update::GREATER_THAN => $this->greaterThan($this->configHelper->getUpdatedGreaterFilter()),
+            Update::LOWER_THAN => $this->lowerThan($this->configHelper->getUpdatedLowerFilter()),
+            Update::BETWEEN => $this->between(
+                $this->configHelper->getUpdatedBetweenAfterFilter(),
+                $this->configHelper->getUpdatedBetweenBeforeFilter()
+            ),
+            Update::SINCE_LAST_N_DAYS => $this->sinceLastNDays($this->configHelper->getUpdatedSinceFilter()),
+            Update::SINCE_LAST_N_HOURS => $this->sinceLastNHours($this->configHelper->getUpdatedSinceLastHoursFilter()),
+            Update::SINCE_LAST_IMPORT => $this->sinceLastImport(),
+            default => [],
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function greaterThan(?string $date): array
+    {
+        return $date ? ['operator' => '>', 'value' => "$date 00:00:00"] : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function lowerThan(?string $date): array
+    {
+        return $date ? ['operator' => '<', 'value' => "$date 23:59:59"] : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function between(?string $after, ?string $before): array
+    {
+        return ($after && $before)
+            ? ['operator' => 'BETWEEN', 'value' => ["$after 00:00:00", "$before 23:59:59"]]
+            : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function sinceLastNDays(?string $days): array
+    {
+        if (!$days || !is_numeric($days)) {
+            return [];
+        }
+        $date = $this->timezone->date()->modify("-$days days");
+
+        return ['operator' => '>', 'value' => $date->format('Y-m-d H:i:s')];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function sinceLastNHours(?string $hours): array
+    {
+        if (!$hours || !is_numeric($hours)) {
+            return [];
+        }
+        $date = $this->timezone->date()->modify("-$hours hours");
+
+        return ['operator' => '>', 'value' => $date->format('Y-m-d H:i:s')];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function sinceLastImport(): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $date = $connection->fetchOne(
+            $connection->select()
+                ->from($this->resourceConnection->getTableName('akeneo_connector_job'), ['last_success_date'])
+                ->where('code = ?', 'product')
+        );
+
+        return $date ? ['operator' => '>', 'value' => $date] : [];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -164,6 +164,19 @@
                     </depends>
                     <can_be_empty>1</can_be_empty>
                 </field>
+                <field id="dynamic_families_enabled" translate="label" type="select" sortOrder="150" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Dynamic Family Filtering</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>
+                        <![CDATA[
+                        <b>Speeds up product imports for large catalogs.</b>
+                        <br/><br/>
+                        First fetches updated products based on "Updated Mode"; then imports only the families found in those results.
+                        <br/><br/>
+                        Example: 936 families total, but only 5 with updates ⇒ only those 5 are processed.
+                        ]]>
+                    </comment>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -17,6 +17,9 @@
                     <api>https://slack.com/api/chat.postMessage</api>
                 </slack>
             </justbetter>
+            <products_filters>
+                <dynamic_families_enabled>0</dynamic_families_enabled>
+            </products_filters>
         </akeneo_connector>
     </default>
 </config>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,6 @@ parameters:
     excludePaths:
         - vendor
     level: 7
+    ignoreErrors:
+        - message: '#\w+Factory#'
+          reportUnmatched: false


### PR DESCRIPTION
### Problem
For catalogs with many product families (e.g., 936 families), the Akeneo product import processes all families sequentially, even when only a few products have been updated. This results in unnecessarily long import times.

### Solution
Added a new option Dynamic Family Filtering that queries Akeneo for products updated within the configured "Updated Mode" period, extracts their family codes, and only imports those families.

### How it works
1. Before import starts, the DynamicFamilyFilter service queries Akeneo API for updated products and product models
2. Extracts unique family codes from the results
3. Intersects with the existing family list (after excluded families are removed)
4. Only matching families are processed

#### Configuration
**Stores > Configuration > Catalog > Akeneo Connector > Products Filters > Dynamic Family Filtering**

The feature uses the existing "Updated Mode" settings (e.g., "Since Last N Hours", "Since Last N Days", etc.)

Example
* Catalog: 936 families
* Updated Mode: "Since Last 1 Hour"
* Products updated: 5 (across 5 different families)
* Result: Only 5 families are imported instead of 936